### PR TITLE
Disable directory listing

### DIFF
--- a/wfe/cknowledge.org/public/.htaccess
+++ b/wfe/cknowledge.org/public/.htaccess
@@ -1,3 +1,5 @@
+Options -Indexes
+
 RewriteEngine On
 RewriteBase /
 


### PR DESCRIPTION
Disable directory listing, e.g. cKnowledge.org/ck-repo-widget should show an error, not directory listing.