### PR TITLE
Fix scenario selection by permalink

### DIFF
--- a/wfe/cknowledge.org/src/repo.html
+++ b/wfe/cknowledge.org/src/repo.html
@@ -32,7 +32,7 @@ function initWidget() {
     const widget = new CkRepoWdiget();
     widget.init({
         isLocalRun: false,
-        scenario: url.searchParams.get("scenario"),
+        scenario: scenario,
         workflows: "/ck-repo-widget/workflows.json",
     });
 }


### PR DESCRIPTION
This should allow to use paths like http://cKnowledge.org/dashboard/<scenario_name>